### PR TITLE
bowtie2.sh: Remove hard-coded tempdir path

### DIFF
--- a/bowtie2.sh
+++ b/bowtie2.sh
@@ -49,7 +49,7 @@ samtools view -bS ${TMPDIR}/$OUTPUT > ${TMPDIR}/${BAM}
 
 echo "Sorting bam"
 #sort using picard
-java –Djava.io.tmpdir=/var/scratch/mkatari/tmp \
+java –Djava.io.tmpdir=$TMPDIR \
 –jar /export/apps/picard-tools/1.112/SortSam.jar \
 INPUT=${TMPDIR}/${BAM} \
 OUTPUT=${TMPDIR}/${SORTED} \


### PR DESCRIPTION
Instead of using a hard-coded value for tempdir path, I think we should use `$TMPDIR` variable. Besides that, only the user mkatari has write permissions on the current tempdir(/var/scratch/mkatari/tmp), therefore, other users may not be able to use it when running `bowtie`.
